### PR TITLE
Replace rn-keychain with rn-encrypted-storage

### DIFF
--- a/js/passwordStore.d.ts
+++ b/js/passwordStore.d.ts
@@ -1,12 +1,11 @@
 import { IPasswordStore } from '@jolocom/sdk/js/storage';
 /**
  * This PasswordStore will use the Android/iOS native secure storage to store a
- * randomly generated 32byte password
+ * randomly generated 32 byte password. Natively, iOS uses the Keychain API
+ * while Android uses the EncryptedSharedPreferences.
  */
 export declare class JolocomKeychainPasswordStore implements IPasswordStore {
-    private service;
-    private username;
-    private nativeLib;
+    private key;
     private setPassword;
     getPassword(): Promise<string>;
 }

--- a/js/passwordStore.js
+++ b/js/passwordStore.js
@@ -2,9 +2,9 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.JolocomKeychainPasswordStore = void 0;
 const tslib_1 = require("tslib");
-const react_native_encrypted_storage_1 = tslib_1.__importDefault(require("react-native-encrypted-storage"));
 // @ts-expect-error No declaration file
 const react_native_randombytes_1 = require("react-native-randombytes");
+const secureStorage_1 = require("./secureStorage");
 /**
  * This PasswordStore will use the Android/iOS native secure storage to store a
  * randomly generated 32 byte password. Natively, iOS uses the Keychain API
@@ -12,24 +12,21 @@ const react_native_randombytes_1 = require("react-native-randombytes");
  */
 class JolocomKeychainPasswordStore {
     constructor() {
-        this.key = 'encryptionPassword';
+        this.key = 'jolocom';
     }
     setPassword(password) {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            yield react_native_encrypted_storage_1.default.setItem(this.key, password);
+            yield secureStorage_1.SecureStorage.storeValue(this.key, password);
         });
     }
     getPassword() {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            const result = yield react_native_encrypted_storage_1.default.getItem(this.key);
-            if (!result) {
-                const password = react_native_randombytes_1.randomBytes(32).toString('base64');
+            let password = yield secureStorage_1.SecureStorage.getValue(this.key);
+            if (!password) {
+                password = react_native_randombytes_1.randomBytes(32).toString('base64');
                 yield this.setPassword(password);
-                return password;
             }
-            else {
-                return result;
-            }
+            return password;
         });
     }
 }

--- a/js/passwordStore.js
+++ b/js/passwordStore.js
@@ -2,39 +2,33 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.JolocomKeychainPasswordStore = void 0;
 const tslib_1 = require("tslib");
-const Keychain = tslib_1.__importStar(require("react-native-keychain"));
-const randomBytes = require('react-native-randombytes').randomBytes;
+const react_native_encrypted_storage_1 = tslib_1.__importDefault(require("react-native-encrypted-storage"));
+// @ts-expect-error No declaration file
+const react_native_randombytes_1 = require("react-native-randombytes");
 /**
  * This PasswordStore will use the Android/iOS native secure storage to store a
- * randomly generated 32byte password
+ * randomly generated 32 byte password. Natively, iOS uses the Keychain API
+ * while Android uses the EncryptedSharedPreferences.
  */
 class JolocomKeychainPasswordStore {
     constructor() {
-        this.service = 'jolocom';
-        this.username = 'JolocomSmartWallet';
-        this.nativeLib = Keychain;
+        this.key = 'encryptionPassword';
     }
     setPassword(password) {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            yield this.nativeLib.setGenericPassword(this.username, password, {
-                service: this.service,
-                storage: Keychain.STORAGE_TYPE.AES,
-            });
+            yield react_native_encrypted_storage_1.default.setItem(this.key, password);
         });
     }
     getPassword() {
         return tslib_1.__awaiter(this, void 0, void 0, function* () {
-            const result = yield this.nativeLib.getGenericPassword({
-                service: this.service
-            });
-            if (result === false) {
-                // there is no password stored
-                const password = randomBytes(32).toString('base64');
+            const result = yield react_native_encrypted_storage_1.default.getItem(this.key);
+            if (!result) {
+                const password = react_native_randombytes_1.randomBytes(32).toString('base64');
                 yield this.setPassword(password);
                 return password;
             }
             else {
-                return result.password;
+                return result;
             }
         });
     }

--- a/js/secureStorage.d.ts
+++ b/js/secureStorage.d.ts
@@ -1,0 +1,5 @@
+export declare class SecureStorage {
+    static storeValue(key: string, value: string): Promise<void>;
+    static getValue(key: string): Promise<string | null>;
+    static removeValue(key: string): Promise<void>;
+}

--- a/js/secureStorage.js
+++ b/js/secureStorage.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SecureStorage = void 0;
+const tslib_1 = require("tslib");
+const react_native_encrypted_storage_1 = tslib_1.__importDefault(require("react-native-encrypted-storage"));
+const Keychain = tslib_1.__importStar(require("react-native-keychain"));
+class SecureStorage {
+    static storeValue(key, value) {
+        return tslib_1.__awaiter(this, void 0, void 0, function* () {
+            yield react_native_encrypted_storage_1.default.setItem(key, value);
+        });
+    }
+    static getValue(key) {
+        return tslib_1.__awaiter(this, void 0, void 0, function* () {
+            const result = yield react_native_encrypted_storage_1.default.getItem(key);
+            // NOTE: Migration from the Keychain package
+            if (!result) {
+                const deprecatedResult = yield Keychain.getGenericPassword({ service: key });
+                if (!deprecatedResult)
+                    return null;
+                yield this.storeValue(key, deprecatedResult.password);
+                return deprecatedResult.password;
+            }
+            return result;
+        });
+    }
+    static removeValue(key) {
+        return tslib_1.__awaiter(this, void 0, void 0, function* () {
+            yield react_native_encrypted_storage_1.default.removeItem(key);
+        });
+    }
+}
+exports.SecureStorage = SecureStorage;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-jolocom",
-  "version": "2.5.0",
+  "version": "2.5.6",
   "description": "React Native environment for Jolocom SDK",
   "main": "js/index.js",
   "files": [
@@ -37,6 +37,7 @@
     "object.assign": "^4.1.0",
     "react-native-crypto": "^2.2.0",
     "react-native-encrypted-storage": "^4.0.2",
+    "react-native-keychain": "6.0.0",
     "react-native-randombytes": "^3.5.3",
     "stream-browserify": "^3.0.0",
     "tslib": "^1.7.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "jolocom-lib": "^5.2.1",
     "object.assign": "^4.1.0",
     "react-native-crypto": "^2.2.0",
-    "react-native-keychain": "^6.0.0",
+    "react-native-encrypted-storage": "^4.0.2",
     "react-native-randombytes": "^3.5.3",
     "stream-browserify": "^3.0.0",
     "tslib": "^1.7.1",

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -7,6 +7,7 @@ export default RNJolocom;
 export * from './transports'
 export * from './storage'
 export * from './passwordStore'
+export * from './secureStorage'
 export * from '@jolocom/sdk'
 export * from 'jolocom-lib'
 /**

--- a/ts/passwordStore.ts
+++ b/ts/passwordStore.ts
@@ -1,7 +1,7 @@
-import EncryptedStorage from 'react-native-encrypted-storage'
 import { IPasswordStore } from '@jolocom/sdk/js/storage'
 // @ts-expect-error No declaration file
 import { randomBytes } from 'react-native-randombytes'
+import { SecureStorage } from './secureStorage'
 
 /**
  * This PasswordStore will use the Android/iOS native secure storage to store a
@@ -10,14 +10,14 @@ import { randomBytes } from 'react-native-randombytes'
  */
 
 export class JolocomKeychainPasswordStore implements IPasswordStore {
-  private key = 'encryptionPassword'
+  private key = 'jolocom'
 
   private async setPassword(password: string): Promise<void> {
-    await EncryptedStorage.setItem(this.key, password)
+    await SecureStorage.storeValue(this.key, password)
   }
 
   async getPassword(): Promise<string> {
-    let password = await EncryptedStorage.getItem(this.key)
+    let password = await SecureStorage.getValue(this.key)
 
     if (!password) {
       password = randomBytes(32).toString('base64') as string

--- a/ts/secureStorage.ts
+++ b/ts/secureStorage.ts
@@ -1,0 +1,27 @@
+import EncryptedStorage from 'react-native-encrypted-storage'
+import * as Keychain from 'react-native-keychain'
+
+export class SecureStorage {
+    static async storeValue(key: string, value: string) {
+        await EncryptedStorage.setItem(key, value)
+    }
+
+    static async getValue(key: string) {
+        const result = await EncryptedStorage.getItem(key)
+
+        // NOTE: Migration from the Keychain package
+        if(!result) {
+            const deprecatedResult = await Keychain.getGenericPassword({ service: key })
+            if(!deprecatedResult) return null
+
+            await this.storeValue(key, deprecatedResult.password)
+            return deprecatedResult.password
+        }
+
+        return result
+    }
+
+    static async removeValue(key:string) {
+        await EncryptedStorage.removeItem(key)
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4731,10 +4731,10 @@ react-native-crypto@^2.2.0:
     public-encrypt "^4.0.0"
     randomfill "^1.0.3"
 
-react-native-keychain@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-6.2.0.tgz#8f4cff503aad367141db5aea0189ead9240c28ff"
-  integrity sha512-U6fnOQRJPq+c0Abl+FoYy9v0H3kQU587tMamU/o+MoBSUScFLE3DQpkyT1PW4NF5IObgiGuqQdmjC2KgtBpjGA==
+react-native-encrypted-storage@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.2.tgz#c7d59b1d3ff2f80d572be3e85aaab3fdee16744a"
+  integrity sha512-vneDkHGDuTvLQjUBztqb2YI8QoH1zxdJonPGTS+g57lfJZff9fAjoLSSb6NgMBebpXFcK3I3sEresGyL+3AArw==
 
 react-native-randombytes@^3.5.3:
   version "3.5.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,6 +4736,11 @@ react-native-encrypted-storage@^4.0.2:
   resolved "https://registry.yarnpkg.com/react-native-encrypted-storage/-/react-native-encrypted-storage-4.0.2.tgz#c7d59b1d3ff2f80d572be3e85aaab3fdee16744a"
   integrity sha512-vneDkHGDuTvLQjUBztqb2YI8QoH1zxdJonPGTS+g57lfJZff9fAjoLSSb6NgMBebpXFcK3I3sEresGyL+3AArw==
 
+react-native-keychain@6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-native-keychain/-/react-native-keychain-6.0.0.tgz#687379dd8468e8c37caa3c4d1c91393c6e04cb1d"
+  integrity sha512-5jt2oS9WNBT/GXBRdb+9KHTQokI1eMRDa50aQFR1koXqUpkULhvxItgQ2CKTd+ZchZQK/hn85qHQOs/gWgUGYA==
+
 react-native-randombytes@^3.5.3:
   version "3.5.3"
   resolved "https://registry.yarnpkg.com/react-native-randombytes/-/react-native-randombytes-3.5.3.tgz#b3bdcd11473cce106551a586244b98855e443cd1"


### PR DESCRIPTION
Due to performance issues caused by the `react-native-keychain` package on the android platform, we agreed to remove its usage and replace it with `react-native-encrypted-storage`, which still uses the Keychain on iOS, while on Android it uses the EncryptedSharedPreferences.