### PR TITLE
feat(exports): nested types and value from sdk and lib

### DIFF
--- a/js/credentials.d.ts
+++ b/js/credentials.d.ts
@@ -1,0 +1,3 @@
+export type { DisplayVal, CredentialIssuer, CredentialDisplay } from '@jolocom/sdk/js/credentials';
+export type { ClaimEntry, IClaimSection } from 'jolocom-lib/js/credentials/credential/types';
+export { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential';

--- a/js/credentials.js
+++ b/js/credentials.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var signedCredential_1 = require("jolocom-lib/js/credentials/signedCredential/signedCredential");
+Object.defineProperty(exports, "SignedCredential", { enumerable: true, get: function () { return signedCredential_1.SignedCredential; } });

--- a/js/interactions.d.ts
+++ b/js/interactions.d.ts
@@ -1,0 +1,7 @@
+export type { AuthenticationFlowState, AuthorizationFlowState, CredentialRequestFlowState, CredentialOfferFlowState, SignedCredentialWithMetadata, InteractionSummary } from '@jolocom/sdk/js/interactionManager/types';
+export type { CredentialOfferFlow } from '@jolocom/sdk/js/interactionManager/credentialOfferFlow';
+export type { FlowState } from '@jolocom/sdk/js/interactionManager/flow';
+export type { InteractionEvents } from '@jolocom/sdk/js/interactionManager/interactionManager';
+export type { CredentialOfferRenderInfo } from 'jolocom-lib/js/interactionTokens/types';
+export type { CredentialRequest } from "jolocom-lib/js/interactionTokens/credentialRequest";
+export { InteractionType } from 'jolocom-lib/js/interactionTokens/types';

--- a/js/interactions.js
+++ b/js/interactions.js
@@ -1,0 +1,4 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var types_1 = require("jolocom-lib/js/interactionTokens/types");
+Object.defineProperty(exports, "InteractionType", { enumerable: true, get: function () { return types_1.InteractionType; } });

--- a/ts/credentials.ts
+++ b/ts/credentials.ts
@@ -1,0 +1,4 @@
+export type { DisplayVal, CredentialIssuer, CredentialDisplay } from '@jolocom/sdk/js/credentials'
+export type { ClaimEntry, IClaimSection } from 'jolocom-lib/js/credentials/credential/types'
+
+export { SignedCredential } from 'jolocom-lib/js/credentials/signedCredential/signedCredential'

--- a/ts/interactions.ts
+++ b/ts/interactions.ts
@@ -1,0 +1,15 @@
+export type {
+  AuthenticationFlowState,
+  AuthorizationFlowState,
+  CredentialRequestFlowState,
+  CredentialOfferFlowState,
+  SignedCredentialWithMetadata,
+  InteractionSummary
+} from '@jolocom/sdk/js/interactionManager/types'
+export type { CredentialOfferFlow } from '@jolocom/sdk/js/interactionManager/credentialOfferFlow'
+export type { FlowState } from '@jolocom/sdk/js/interactionManager/flow'
+export type { InteractionEvents } from '@jolocom/sdk/js/interactionManager/interactionManager'
+export type { CredentialOfferRenderInfo } from 'jolocom-lib/js/interactionTokens/types'
+export type { CredentialRequest } from "jolocom-lib/js/interactionTokens/credentialRequest"
+
+export { InteractionType } from 'jolocom-lib/js/interactionTokens/types'


### PR DESCRIPTION
This is fairly redundant improvement. When installing react-native-jolocon lib and sdk are available as dependencies from the wallet